### PR TITLE
Fix webnovel extension and added support for fanfics

### DIFF
--- a/sources/en/webnovelcom/build.gradle.kts
+++ b/sources/en/webnovelcom/build.gradle.kts
@@ -1,7 +1,7 @@
 listOf("en").map { lang ->
   Extension(
     name = "WebNovelCom",
-    versionCode = 6,
+    versionCode = 7,
     libVersion = "1",
     lang = lang,
     description = "",


### PR DESCRIPTION
Updates
- Made webnovel work again, added support for fanfic 
- Searching for fanfic possible through adding prefix fanfic before title

Description
webnovel does not search for fanfic if you don't specify type=fanfic in URL thus default query will only search on the novel database

https://www.webnovel.com/search?keywords=fanfic+reborn+as+yamanaka&type=fanfic&pageIndex=1

thus if we want to search fanfic we need prefix the query with fanfic.

E.g. 
- fanfic reborn as yamanaka
- fanfic Nascent Kaleidoscope
- fanfic hogwarts
- fanfic one piece
- fanfic naruto
