### PR TITLE
fix(rewayatfansnet): add browse sections and fix covers

### DIFF
--- a/sources/ar/rewayatfansnet/build.gradle.kts
+++ b/sources/ar/rewayatfansnet/build.gradle.kts
@@ -1,7 +1,7 @@
 listOf("ar").map { lang ->
   Extension(
     name = "RewayatfansNet",
-    versionCode = 4,
+    versionCode = 5,
     libVersion = "2",
     lang = lang,
     description = "",

--- a/sources/ar/rewayatfansnet/main/src/ireader/rewayatfansnet/Rewayatfans.kt
+++ b/sources/ar/rewayatfansnet/main/src/ireader/rewayatfansnet/Rewayatfans.kt
@@ -1,12 +1,9 @@
 package ireader.rewayatfansnet
 
 import com.fleeksoft.ksoup.nodes.Document
-import io.ktor.client.request.HttpRequestBuilder
+import com.fleeksoft.ksoup.nodes.Element
 import io.ktor.client.request.get
-import io.ktor.client.request.headers
-import io.ktor.http.HeadersBuilder
-import io.ktor.http.HttpHeaders
-import ireader.core.log.Log
+import io.ktor.http.decodeURLPart
 import ireader.core.source.Dependencies
 import ireader.core.source.asJsoup
 import ireader.core.source.findInstance
@@ -16,14 +13,11 @@ import ireader.core.source.model.Filter
 import ireader.core.source.model.FilterList
 import ireader.core.source.model.MangaInfo
 import ireader.core.source.SourceFactory
-import ireader.core.source.dsl.filters
 import ireader.core.source.model.ChapterInfo
-import ireader.core.source.model.Listing
-import ireader.core.source.model.MangasPageInfo
 import tachiyomix.annotations.Extension
 
 @Extension
-abstract class RewayatFans(deps: Dependencies) : SourceFactory(
+abstract class RewayatFansNet(deps: Dependencies) : SourceFactory(
     deps = deps,
 ) {
     override val lang: String
@@ -31,18 +25,12 @@ abstract class RewayatFans(deps: Dependencies) : SourceFactory(
     override val baseUrl: String
         get() = "https://rewayahfans.net"
     override val id: Long
-        get() = 42
+        get() = 4202
     override val name: String
-        get() = "روايات فانز"
+        get() = "روايات فانز (نت)"
 
     override fun getFilters(): FilterList = listOf(
         Filter.Title(),
-        Filter.Sort(
-            "الترتيب حسب:",
-            arrayOf(
-                "latest",
-            )
-        ),
     )
 
     override fun getCommands(): CommandList = listOf(
@@ -54,23 +42,44 @@ abstract class RewayatFans(deps: Dependencies) : SourceFactory(
     override val exploreFetchers: List<BaseExploreFetcher>
         get() = listOf(
             BaseExploreFetcher(
-                "Latest",
-                endpoint = "/%d9%82%d8%a7%d8%a6%d9%85%d8%a9-%d8%a7%d9%84%d8%b1%d9%88%d8%a7%d9%8a%d8%a7%d8%aa/",
-                selector = "figure.wp-block-image",
-                nameSelector = ".wp-element-caption a",
-                linkSelector = ".wp-element-caption a",
+                "الأحدث",
+                endpoint = "/",
+                selector = "figure.wp-block-image, figure.wp-block-media-text__media",
+                nameSelector = "figcaption a, figcaption strong a",
+                linkSelector = "figcaption a, figcaption strong a",
                 linkAtt = "href",
                 coverSelector = "img",
                 coverAtt = "src",
-                maxPage = 5,
-                type = Type.Others
+                maxPage = 1,
             ),
             BaseExploreFetcher(
-                "Latest",
+                "جميع الروايات",
+                endpoint = "/%d9%82%d8%a7%d8%a6%d9%85%d8%a9-%d8%a7%d9%84%d8%b1%d9%88%d8%a7%d9%8a%d8%a7%d8%aa/",
+                selector = "figure.wp-block-image",
+                nameSelector = "figcaption a, figcaption strong a",
+                linkSelector = "figcaption a, figcaption strong a",
+                linkAtt = "href",
+                coverSelector = "img",
+                coverAtt = "src",
+                maxPage = 1,
+            ),
+            BaseExploreFetcher(
+                "الروايات المكتملة",
+                endpoint = "/%d8%a7%d9%84%d8%b1%d9%88%d8%a7%d9%8a%d8%a7%d8%aa-%d8%a7%d9%84%d9%85%d9%83%d8%aa%d9%85%d9%84%d8%a9/",
+                selector = "figure.wp-block-image",
+                nameSelector = "figcaption a, figcaption strong a",
+                linkSelector = "figcaption a, figcaption strong a",
+                linkAtt = "href",
+                coverSelector = "img",
+                coverAtt = "src",
+                maxPage = 1,
+            ),
+            BaseExploreFetcher(
+                "Search",
                 endpoint = "/page/{page}/?s={query}",
                 selector = "figure.wp-block-image",
-                nameSelector = ".wp-element-caption a",
-                linkSelector = ".wp-element-caption a",
+                nameSelector = ".wp-element-caption a, .wp-element-caption strong a",
+                linkSelector = ".wp-element-caption a, .wp-element-caption strong a",
                 linkAtt = "href",
                 coverSelector = "img",
                 coverAtt = "src",
@@ -78,58 +87,83 @@ abstract class RewayatFans(deps: Dependencies) : SourceFactory(
                 type = Type.Search
             ),
         )
+
+    override fun parseMangaFromElement(
+        element: Element,
+        fetcher: BaseExploreFetcher
+    ): MangaInfo {
+        var title = selectorReturnerStringType(element, fetcher.nameSelector, fetcher.nameAtt).trim()
+        var url = selectorReturnerStringType(element, fetcher.linkSelector, fetcher.linkAtt).trim()
+        if (url.isBlank()) {
+            url = element.select("a[href]").firstOrNull()?.attr("href")?.trim().orEmpty()
+        }
+        if (url.isBlank()) {
+            url = element.select("img[data-permalink]").firstOrNull()?.attr("data-permalink")?.trim().orEmpty()
+        }
+        if (title.isBlank() && url.isNotBlank()) {
+            val slug = url.substringBefore('?').trimEnd('/').substringAfterLast('/')
+            title = slug.replace("-", " ").decodeURLPart()
+        }
+        val img = element.select(fetcher.coverSelector ?: "img").firstOrNull()
+        val cover = img?.let {
+            val src = it.attr("src").trim()
+            val dataSrc = it.attr("data-src").trim()
+            val dataLazySrc = it.attr("data-lazy-src").trim()
+            val raw = when {
+                dataSrc.isNotBlank() && !dataSrc.startsWith("data:") -> dataSrc
+                dataLazySrc.isNotBlank() && !dataLazySrc.startsWith("data:") -> dataLazySrc
+                src.isNotBlank() && !src.startsWith("data:") -> src
+                else -> ""
+            }
+            if (raw.isBlank()) "" else {
+                val marker = "rewayahfans.net/wp-content/"
+                val idx = raw.substringBefore('?').indexOf(marker)
+                if (idx >= 0) "https://" + raw.substringBefore('?').substring(idx)
+                else raw
+            }
+        } ?: ""
+        return MangaInfo(key = url, title = title, cover = cover)
+    }
+
     override val detailFetcher: Detail
         get() = Detail(
-            nameSelector = "figure.wp-block-image ",
-//            coverSelector = "img",
-//            coverAtt = "src",
-            descriptionSelector = "",  // Handled in getMangaDetails
+            nameSelector = "figure.wp-block-image",
+            coverSelector = "img",
+            coverAtt = "src",
+            descriptionSelector = "",
         )
 
-    // Custom description parsing: get <p> tags between .crowdsignal-vote-wrapper and .has-large-font-size
     private fun parseDescriptionBetweenH2(document: Document): String {
         val entryContent = document.selectFirst("div.entry-content") ?: return ""
         val paragraphs = mutableListOf<String>()
-
         var collecting = false
         for (element in entryContent.children()) {
-            // Start collecting after .crowdsignal-vote-wrapper
             if (element.hasClass("has-large-font-size")) {
                 collecting = true
                 continue
             }
-            // Stop collecting when hitting .has-large-font-size
-            if (element.hasClass("crowdsignal-vote-wrapper")) {
-                break
-            }
-            // Collect <p> tags while in the collecting zone
+            if (element.hasClass("crowdsignal-vote-wrapper")) break
             if (collecting && element.tagName() == "p") {
                 val text = element.text().trim()
-                if (text.isNotBlank()) {
-                    paragraphs.add(text)
-                }
+                if (text.isNotBlank()) paragraphs.add(text)
             }
         }
-
         return paragraphs.joinToString("\n\n")
     }
 
     override suspend fun getMangaDetails(manga: MangaInfo, commands: List<Command<*>>): MangaInfo {
-        // Check for WebView HTML first
         val detailFetch = commands.findInstance<Command.Detail.Fetch>()
         if (detailFetch != null && detailFetch.html.isNotBlank()) {
             val document = detailFetch.html.asJsoup()
-            val baseInfo = detailParse(document, )
+            val baseInfo = detailParse(document)
             val description = parseDescriptionBetweenH2(document)
             return baseInfo.copy(description = description)
         }
-
         val document = client.get(requestBuilder(manga.key)).asJsoup()
         val baseInfo = detailParse(document)
         val description = parseDescriptionBetweenH2(document)
         return baseInfo.copy(description = description)
     }
-
 
     override val chapterFetcher: Chapters
         get() = Chapters(
@@ -146,9 +180,7 @@ abstract class RewayatFans(deps: Dependencies) : SourceFactory(
         )
 
     override fun chaptersParse(document: Document): List<ChapterInfo> {
-        Log.error { document.html() }
         val selector = chapterFetcher.selector ?: return emptyList()
-
         return document.select(selector).mapNotNull { element ->
             runCatching { chapterFromElement(element) }
                 .getOrNull()


### PR DESCRIPTION
- Add browse sections matching the rewayatfans source: الأحدث, جميع الروايات, الروايات المكتملة + Search
- rewayahfans.net has no real pagination, so each section loads one page (maxPage = 1)
- Fix empty Latest section: homepage figures have no figcaption/title, so titles are now derived from the URL slug (decoded)
- Fix covers not loading in the app: strip the Jetpack CDN (i0.wp.com) prefix and query params, use direct https://rewayahfans.net/wp-content/... URLs
- Bump versionCode 4 -> 5