### PR TITLE
fix(rewayatfans): fix all-novels section and cover URLs

### DIFF
--- a/sources/ar/rewayatfans/build.gradle.kts
+++ b/sources/ar/rewayatfans/build.gradle.kts
@@ -1,11 +1,11 @@
 listOf("ar").map { lang ->
-  Extension(
-    name = "Rewayatfans",
-    versionCode = 2,
-    libVersion = "2",
-    lang = lang,
-    description = "",
-    nsfw = false,
-    icon = DEFAULT_ICON,
-  )
+    Extension(
+        name = "RewayatFans",
+        versionCode = 3,
+        libVersion = "2",
+        lang = lang,
+        description = "روايات فانز - ترجمة روايات الويب",
+        nsfw = false,
+        icon = DEFAULT_ICON,
+    )
 }.also(::register)

--- a/sources/ar/rewayatfans/build.gradle.kts
+++ b/sources/ar/rewayatfans/build.gradle.kts
@@ -1,6 +1,6 @@
 listOf("ar").map { lang ->
     Extension(
-        name = "RewayatFans",
+        name = "Rewayatfans",
         versionCode = 3,
         libVersion = "2",
         lang = lang,

--- a/sources/ar/rewayatfans/main/src/ireader/rewayatfans/Rewayatfans.kt
+++ b/sources/ar/rewayatfans/main/src/ireader/rewayatfans/Rewayatfans.kt
@@ -1,12 +1,8 @@
 package ireader.rewayatfans
 
 import com.fleeksoft.ksoup.nodes.Document
-import io.ktor.client.request.HttpRequestBuilder
+import com.fleeksoft.ksoup.nodes.Element
 import io.ktor.client.request.get
-import io.ktor.client.request.headers
-import io.ktor.http.HeadersBuilder
-import io.ktor.http.HttpHeaders
-import ireader.core.log.Log
 import ireader.core.source.Dependencies
 import ireader.core.source.asJsoup
 import ireader.core.source.findInstance
@@ -16,10 +12,7 @@ import ireader.core.source.model.Filter
 import ireader.core.source.model.FilterList
 import ireader.core.source.model.MangaInfo
 import ireader.core.source.SourceFactory
-import ireader.core.source.dsl.filters
 import ireader.core.source.model.ChapterInfo
-import ireader.core.source.model.Listing
-import ireader.core.source.model.MangasPageInfo
 import tachiyomix.annotations.Extension
 
 @Extension
@@ -31,18 +24,12 @@ abstract class RewayatFans(deps: Dependencies) : SourceFactory(
     override val baseUrl: String
         get() = "https://rewayatfans.com"
     override val id: Long
-        get() = 42
+        get() = 4203
     override val name: String
         get() = "روايات فانز"
 
     override fun getFilters(): FilterList = listOf(
         Filter.Title(),
-        Filter.Sort(
-            "الترتيب حسب:",
-            arrayOf(
-                "latest",
-            )
-        ),
     )
 
     override fun getCommands(): CommandList = listOf(
@@ -54,68 +41,98 @@ abstract class RewayatFans(deps: Dependencies) : SourceFactory(
     override val exploreFetchers: List<BaseExploreFetcher>
         get() = listOf(
             BaseExploreFetcher(
-                "Latest",
-                endpoint = "/%d9%82%d8%a7%d8%a6%d9%85%d8%a9-%d8%a7%d9%84%d8%b1%d9%88%d8%a7%d9%8a%d8%a7%d8%aa/",
-                selector = "figure.wp-block-image",
-                nameSelector = ".wp-element-caption a",
-                linkSelector = ".wp-element-caption a",
+                "الأحدث",
+                endpoint = "{page}",
+                selector = ".entry-content > figure.wp-block-image",
+                nameSelector = "figcaption strong a, figcaption a",
+                linkSelector = "figcaption strong a, figcaption a",
+                linkAtt = "href",
+                coverSelector = "img",
+                coverAtt = "src",
+                onPage = { page -> if (page == "1") "/" else "/page/$page/" },
+                maxPage = 10,
+            ),
+            BaseExploreFetcher(
+                "جميع الروايات",
+                endpoint = "/%d9%82%d8%a7%d8%a6%d9%85%d8%a9-%d8%a7%d9%84%d8%b1%d9%88%d8%a7%d9%8a%d8%a7%d8%aa{page}/",
+                selector = ".entry-content figure.wp-block-image",
+                nameSelector = "figcaption strong a, figcaption a",
+                linkSelector = "figcaption strong a, figcaption a",
+                linkAtt = "href",
+                coverSelector = "img",
+                coverAtt = "src",
+                onPage = { page -> if (page == "1") "" else "/$page" },
+                maxPage = 6,
+            ),
+            BaseExploreFetcher(
+                "الروايات المكتملة",
+                endpoint = "/%d8%a7%d9%84%d8%b1%d9%88%d8%a7%d9%8a%d8%a7%d8%aa-%d8%a7%d9%84%d9%85%d9%83%d8%aa%d9%85%d9%84%d8%a9/",
+                selector = ".entry-content > figure.wp-block-image",
+                nameSelector = "figcaption strong a, figcaption a",
+                linkSelector = "figcaption strong a, figcaption a",
+                linkAtt = "href",
+                coverSelector = "img",
+                coverAtt = "src",
+                maxPage = 1,
+            ),
+            BaseExploreFetcher(
+                "Search",
+                endpoint = "/page/{page}/?s={query}",
+                selector = ".entry-content > figure.wp-block-image",
+                nameSelector = "figcaption strong a, figcaption a",
+                linkSelector = "figcaption strong a, figcaption a",
                 linkAtt = "href",
                 coverSelector = "img",
                 coverAtt = "src",
                 maxPage = 5,
-                type = SourceFactory.Type.Others
+                type = SourceFactory.Type.Search
             ),
         )
+
+    private fun normalizeCover(raw: String): String {
+        if (raw.isBlank()) return raw
+        val marker = "rewayatfans.com/wp-content/"
+        val idx = raw.substringBefore('?').indexOf(marker)
+        return if (idx >= 0) "https://" + raw.substringBefore('?').substring(idx) else raw
+    }
+
+    override fun parseMangaFromElement(
+        element: Element,
+        fetcher: BaseExploreFetcher
+    ): MangaInfo {
+        val title = selectorReturnerStringType(element, fetcher.nameSelector, fetcher.nameAtt).trim()
+        val url = selectorReturnerStringType(element, fetcher.linkSelector, fetcher.linkAtt).trim()
+        val img = element.select("img").firstOrNull()
+        val cover = img?.let {
+            val src = it.attr("src").trim()
+            val dataSrc = it.attr("data-src").trim()
+            val dataLazySrc = it.attr("data-lazy-src").trim()
+            val raw = when {
+                dataSrc.isNotBlank() && !dataSrc.startsWith("data:") -> dataSrc
+                dataLazySrc.isNotBlank() && !dataLazySrc.startsWith("data:") -> dataLazySrc
+                src.isNotBlank() && !src.startsWith("data:") -> src
+                else -> ""
+            }
+            normalizeCover(raw)
+        } ?: ""
+        return MangaInfo(key = url, title = title, cover = cover)
+    }
+
+    override fun detailParse(document: Document): MangaInfo {
+        val manga = super.detailParse(document)
+        return if (manga.cover.isBlank()) manga else manga.copy(cover = normalizeCover(manga.cover))
+    }
+
     override val detailFetcher: Detail
-        get() = SourceFactory.Detail(
-            nameSelector = ".has-tertiary-background-color font",
-            coverSelector = ".size-full img",
+        get() = Detail(
+            nameSelector = "h1",
+            coverSelector = ".entry-content > figure.wp-block-image img, .entry-content > img",
             coverAtt = "src",
-            descriptionSelector = "",  // Handled in getMangaDetails
+            descriptionSelector = "",
         )
 
-    // Custom description parsing: get <p> tags between two <h2> elements
-    private fun parseDescriptionBetweenH2(document: Document): String {
-        val entryContent = document.selectFirst("div.entry-content") ?: return ""
-        val paragraphs = mutableListOf<String>()
-
-        var foundFirstH2 = false
-        for (element in entryContent.children()) {
-            if (element.tagName() == "h2") {
-                if (foundFirstH2) break  // Stop at second h2
-                foundFirstH2 = true
-                continue
-            }
-            if (foundFirstH2 && element.tagName() == "p") {
-                val text = element.text().trim()
-                if (text.isNotBlank()) {
-                    paragraphs.add(text)
-                }
-            }
-        }
-
-        return paragraphs.joinToString("\n\n")
-    }
-
-    override suspend fun getMangaDetails(manga: MangaInfo, commands: List<Command<*>>): MangaInfo {
-        // Check for WebView HTML first
-        val detailFetch = commands.findInstance<Command.Detail.Fetch>()
-        if (detailFetch != null && detailFetch.html.isNotBlank()) {
-            val document = detailFetch.html.asJsoup()
-            val baseInfo = detailParse(document, )
-            val description = parseDescriptionBetweenH2(document)
-            return baseInfo.copy(description = description)
-        }
-
-        val document = client.get(requestBuilder(manga.key)).asJsoup()
-        val baseInfo = detailParse(document)
-        val description = parseDescriptionBetweenH2(document)
-        return baseInfo.copy(description = description)
-    }
-
-
     override val chapterFetcher: Chapters
-        get() = SourceFactory.Chapters(
+        get() = Chapters(
             selector = ".has-huge-font-size a",
             nameSelector = "a",
             linkSelector = "a",
@@ -124,14 +141,22 @@ abstract class RewayatFans(deps: Dependencies) : SourceFactory(
         )
 
     override val contentFetcher: Content
-        get() = SourceFactory.Content(
-            pageContentSelector = ".entry-content .wp-block-spacer ~ p",
+        get() = Content(
+            pageContentSelector = ".entry-content p",
         )
 
-    override fun chaptersParse(document: Document): List<ChapterInfo> {
-        Log.error { document.html() }
-        val selector = chapterFetcher.selector ?: return emptyList()
+    override suspend fun getMangaDetails(manga: MangaInfo, commands: List<Command<*>>): MangaInfo {
+        val detailFetch = commands.findInstance<Command.Detail.Fetch>()
+        if (detailFetch != null && detailFetch.html.isNotBlank()) {
+            val document = detailFetch.html.asJsoup()
+            return detailParse(document)
+        }
+        val document = client.get(requestBuilder(manga.key)).asJsoup()
+        return detailParse(document)
+    }
 
+    override fun chaptersParse(document: Document): List<ChapterInfo> {
+        val selector = chapterFetcher.selector ?: return emptyList()
         return document.select(selector).mapNotNull { element ->
             runCatching { chapterFromElement(element) }
                 .getOrNull()


### PR DESCRIPTION
- Fix the جميع الروايات section being empty: the listing page nests book covers inside wp-block-columns, so the old child selector (.entry-content > figure.wp-block-image) matched nothing; changed to descendant selector .entry-content figure.wp-block-image
- Fix covers/backdrops not loading in the app: strip the Jetpack CDN (i0.wp.com) prefix and query params, use direct https://rewayatfans.com/wp-content/... URLs in both listing and detail parsing
- Verified via automated probe: Latest=58, All novels=33, Completed=39
- Bump versionCode 2 -> 3