### PR TITLE
fix(riwyat): update chapter content selector

### DIFF
--- a/sources/ar/riwyat/main/src/ireader/riwyat/Riwyat.kt
+++ b/sources/ar/riwyat/main/src/ireader/riwyat/Riwyat.kt
@@ -192,7 +192,7 @@ abstract class Riwyat(private val deps: Dependencies) : SourceFactory(
     override val contentFetcher: Content
         get() = SourceFactory.Content(
             pageTitleSelector = "h3.chapter-name",
-            pageContentSelector = ".reading-content-wrap.chapter-type-text .text-left p",
+            pageContentSelector = ".reading-content p",
         )
 
     private val invisibleCharRegex = Regex(


### PR DESCRIPTION
Update pageContentSelector from .reading-content-wrap.chapter-type-text .text-left p to .reading-content p to match the current site HTML.