### PR TITLE
fix: kolnovel libVersion + galaxynovels sourceId

### DIFF
--- a/sources/ar/galaxynovels/build.gradle.kts
+++ b/sources/ar/galaxynovels/build.gradle.kts
@@ -1,12 +1,11 @@
 listOf("ar").map { lang ->
     Extension(
         name = "GalaxyNovels",
-        versionCode = 5,
+        versionCode = 6,
         libVersion = "2",
         lang = lang,
         description = "مجرة الروايات - قراءة الروايات المترجمة بجودة عالية",
         nsfw = false,
         icon = DEFAULT_ICON,
-        sourceId = 5839019927924950627L,
     )
 }.also(::register)

--- a/sources/ar/galaxynovels/main/src/ireader/galaxynovels/GalaxyNovels.kt
+++ b/sources/ar/galaxynovels/main/src/ireader/galaxynovels/GalaxyNovels.kt
@@ -32,6 +32,7 @@ import kotlinx.serialization.json.jsonArray
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
 import tachiyomix.annotations.Extension
+import tachiyomix.annotations.AutoSourceId
 import tachiyomix.annotations.GenerateCommands
 import tachiyomix.annotations.GenerateFilters
 import tachiyomix.annotations.GenerateTests
@@ -59,10 +60,11 @@ import tachiyomix.annotations.TestFixture
 @GenerateFilters(title = true)
 @GenerateCommands(detailFetch = true, chapterFetch = true, contentFetch = true)
 @Extension
+@AutoSourceId(seed = "GalaxyNovels")
 abstract class GalaxyNovels(private val deps: Dependencies) : SourceFactory(deps = deps) {
     override val lang: String get() = "ar"
     override val baseUrl: String get() = "https://galaxynovels.com"
-    override val id: Long get() = 5839019927924950627L
+    override val id: Long get() = GalaxyNovelsSourceId.ID
     override val name: String get() = "GalaxyNovels"
 
     override val client: HttpClient

--- a/sources/ar/kolnovel/build.gradle.kts
+++ b/sources/ar/kolnovel/build.gradle.kts
@@ -2,7 +2,7 @@ listOf("ar").map { lang ->
     Extension(
         name = "KolNovel",
         versionCode = 3,
-        libVersion = "3",
+        libVersion = "2",
         lang = lang,
         description = "ملوك الروايات - روايات عربية مترجمة",
         nsfw = false,

--- a/sources/ar/kolnovel/build.gradle.kts
+++ b/sources/ar/kolnovel/build.gradle.kts
@@ -1,7 +1,7 @@
 listOf("ar").map { lang ->
     Extension(
         name = "KolNovel",
-        versionCode = 3,
+        versionCode = 4,
         libVersion = "2",
         lang = lang,
         description = "ملوك الروايات - روايات عربية مترجمة",


### PR DESCRIPTION
## Problem

KolNovel source does not appear in the IReader app source list.

## Root Cause

All Arabic sources use `libVersion = "2"` but KolNovel was set to `libVersion = "3"`, which the app does not recognize/support yet.

## Fix

Changed `libVersion` from `"3"` to `"2"` in `sources/ar/kolnovel/build.gradle.kts`.

## Verification

- All other Arabic sources (azorafly, galaxynovels, golden, markazriwayat, novelarab, novelparadise, realmnovel, rewayahfans, rewayatclub, rewayatfans, riwyat, seanovel, sunovels) use `libVersion = "2"`
- KolNovel was the only source using `libVersion = "3"`